### PR TITLE
Update: hyprpaper Handler to set all screens

### DIFF
--- a/wallpaperDaemonHandlerScripts/hyprpaper@5hubham5ingh.js
+++ b/wallpaperDaemonHandlerScripts/hyprpaper@5hubham5ingh.js
@@ -7,5 +7,5 @@
 export function setWallpaper(wallpaperPath) {
   OS.exec(["hyprctl", "-q", "hyprpaper unload all"]);
   OS.exec(["hyprctl", "-q", `hyprpaper preload ${wallpaperPath}`]);
-  OS.exec(["hyprctl", "-q", `hyprpaper wallpaper eDP-1,${wallpaperPath}`]);
+  OS.exec(["hyprctl", "-q", `hyprpaper wallpaper ,${wallpaperPath}`]);
 }


### PR DESCRIPTION
Update hyprpaper handler to change wallpaper for all screens. It makes sense for this to be the default behaviour. People who only want to change 1 display's wallpaper can always update the handler script to specify a display to set.